### PR TITLE
Error when # of rows and columns are different

### DIFF
--- a/src/Rcart.c
+++ b/src/Rcart.c
@@ -114,7 +114,7 @@ R_predict(SEXP obj, SEXP r_x, SEXP r_y, SEXP r_ans, SEXP r_dims)
 	dx = x[i] - ix - 1.;
 	dy = y[i] - iy - 1.;
 
-	if(ix < 0 || ix >= dims[0] || iy < 0 || iy >= dims[1]) {
+	if(ix < 0 || ix >= dims[1] || iy < 0 || iy >= dims[0]) {
 	    continue;
 	}
 


### PR DESCRIPTION
Have to switch the dims for x and y, otherwise they don't match
## Example -- Test

m = matrix(1, 3, 5)
mm = col(m) + row(m)
ex = addBoundary(mm,0.5)
image(ex)
cart = cartogram(ex)
pred1=predict(cart,rep(1:9,each=5),rep(1:5,9))
plot(pred1)  # 5x5 matrix, but should be 9x5
